### PR TITLE
ngbx-modal in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ this.toastService.error('Account', 'Failed to delete account', error);
 2. Create a component, e.g. `EditUserComponent`:
 
   ```angular2html
-  <app-modal #modal="modal" [back]="['../..']">
+  <ngbx-modal #modal="modal" [back]="['../..']">
     <ng-container modal-header>
       Edit User
     </ng-container>
@@ -67,7 +67,7 @@ this.toastService.error('Account', 'Failed to delete account', error);
         Save
       </button>
     </ng-container>
-  </app-modal>
+  </ngbx-modal>
   ```
 
 3. Add `<router-outlet></router-outlet>` to the end of the parent component (e.g. `UserListComponent`).

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ this.toastService.error('Account', 'Failed to delete account', error);
 
   ```angular2html
   <ngbx-modal #modal="modal" [back]="['../..']">
-    <ng-container modal-header>
+    <ng-container modal-title>
       Edit User
     </ng-container>
     <ng-container modal-body>


### PR DESCRIPTION
# Context
Renamed `app-modal` to `ngbx-modal` to fix the given example in the `README.md`.
Additionally changed the `modal-header` to `modal-title`.